### PR TITLE
Remove reference to OpenSim.Framework.Communications

### DIFF
--- a/addon-modules/OMEconomy/OMEconomy.OMCurrency/OMCurrency.cs
+++ b/addon-modules/OMEconomy/OMEconomy.OMCurrency/OMCurrency.cs
@@ -45,7 +45,6 @@ using LitJson;
 using Mono.Addins;
 using OpenMetaverse;
 using OpenSim.Framework;
-using OpenSim.Framework.Communications;
 using OpenSim.Framework.Servers;
 using OpenSim.Region.Framework.Interfaces;
 using OpenSim.Region.Framework.Scenes;

--- a/addon-modules/OMEconomy/prebuild.OMCurrency.xml
+++ b/addon-modules/OMEconomy/prebuild.OMCurrency.xml
@@ -24,7 +24,6 @@
   <Reference name="Mono.Addins" path="../../../bin/"/>
   <Reference name="OpenSim.Framework"/>
   <Reference name="OpenSim.Region.Framework"/>
-  <Reference name="OpenSim.Framework.Communications"/>
   <Reference name="OpenSim.Framework.Servers"/>
   <Reference name="OpenSim.Framework.Servers.HttpServer"/>
   <Reference name="OpenSim.Region.Framework"/>


### PR DESCRIPTION
What was left in OpenSim.Framework.Communications was merged merged into OpenSim.Framework so remove the reference

See also:
http://opensimulator.org/viewgit/?a=commit&p=opensim&h=d00f73c3a4cac77c97dcf4df1613fb85a516ffb4